### PR TITLE
Feat(#22): add django models

### DIFF
--- a/backend/kernelCI/settings.py
+++ b/backend/kernelCI/settings.py
@@ -45,7 +45,6 @@ ALLOWED_HOSTS = get_json_env_var(
     ['localhost'],
 )
 
-
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/kernelCI_app/models.py
+++ b/backend/kernelCI_app/models.py
@@ -1,3 +1,112 @@
-# from django.db import models
+from django.db import models
 
-# Create your models here.
+
+class Tests(models.Model):
+    field_timestamp = models.DateTimeField(db_column='_timestamp', blank=True, null=True)
+    build_id = models.TextField()
+    id = models.TextField(primary_key=True)
+    origin = models.TextField()
+    environment_comment = models.TextField(blank=True, null=True)
+    environment_misc = models.JSONField(blank=True, null=True)
+    path = models.TextField(blank=True, null=True)
+    comment = models.TextField(blank=True, null=True)
+    log_url = models.TextField(blank=True, null=True)
+    log_excerpt = models.CharField(max_length=16384, blank=True, null=True)
+    status = models.TextField(blank=True, null=True)  # This field type is a guess.
+    waived = models.BooleanField(blank=True, null=True)
+    start_time = models.DateTimeField(blank=True, null=True)
+    duration = models.FloatField(blank=True, null=True)
+    output_files = models.JSONField(blank=True, null=True)
+    misc = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'tests'
+
+
+class Issues(models.Model):
+    field_timestamp = models.DateTimeField(db_column='_timestamp', blank=True, null=True)
+    id = models.TextField(primary_key=True)
+    version = models.IntegerField()
+    origin = models.TextField()
+    report_url = models.TextField(blank=True, null=True)
+    report_subject = models.TextField(blank=True, null=True)
+    culprit_code = models.BooleanField(blank=True, null=True)
+    culprit_tool = models.BooleanField(blank=True, null=True)
+    culprit_harness = models.BooleanField(blank=True, null=True)
+    build_valid = models.BooleanField(blank=True, null=True)
+    test_status = models.TextField(blank=True, null=True)
+    comment = models.TextField(blank=True, null=True)
+    misc = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'issues'
+        unique_together = (('id', 'version'),)
+
+
+class Incidents(models.Model):
+    field_timestamp = models.DateTimeField(db_column='_timestamp', blank=True, null=True)
+    id = models.TextField(primary_key=True)
+    origin = models.TextField()
+    issue_id = models.TextField()
+    issue_version = models.IntegerField()
+    build_id = models.TextField(blank=True, null=True)
+    test_id = models.TextField(blank=True, null=True)
+    present = models.BooleanField(blank=True, null=True)
+    comment = models.TextField(blank=True, null=True)
+    misc = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'incidents'
+
+
+class Checkouts(models.Model):
+    field_timestamp = models.DateTimeField(db_column='_timestamp', blank=True, null=True)
+    id = models.TextField(primary_key=True)
+    origin = models.TextField()
+    tree_name = models.TextField(blank=True, null=True)
+    git_repository_url = models.TextField(blank=True, null=True)
+    git_commit_hash = models.TextField(blank=True, null=True)
+    git_commit_name = models.TextField(blank=True, null=True)
+    git_repository_branch = models.TextField(blank=True, null=True)
+    patchset_files = models.JSONField(blank=True, null=True)
+    patchset_hash = models.TextField(blank=True, null=True)
+    message_id = models.TextField(blank=True, null=True)
+    comment = models.TextField(blank=True, null=True)
+    start_time = models.DateTimeField(blank=True, null=True)
+    contacts = models.JSONField(blank=True, null=True)
+    log_url = models.TextField(blank=True, null=True)
+    log_excerpt = models.CharField(max_length=16384, blank=True, null=True)
+    valid = models.BooleanField(blank=True, null=True)
+    misc = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'checkouts'
+
+
+class Builds(models.Model):
+    field_timestamp = models.DateTimeField(db_column='_timestamp', blank=True, null=True)
+    checkout_id = models.TextField()
+    id = models.TextField(primary_key=True)
+    origin = models.TextField()
+    comment = models.TextField(blank=True, null=True)
+    start_time = models.DateTimeField(blank=True, null=True)
+    duration = models.FloatField(blank=True, null=True)
+    architecture = models.TextField(blank=True, null=True)
+    command = models.TextField(blank=True, null=True)
+    compiler = models.TextField(blank=True, null=True)
+    input_files = models.JSONField(blank=True, null=True)
+    output_files = models.JSONField(blank=True, null=True)
+    config_name = models.TextField(blank=True, null=True)
+    config_url = models.TextField(blank=True, null=True)
+    log_url = models.TextField(blank=True, null=True)
+    log_excerpt = models.CharField(max_length=16384, blank=True, null=True)
+    valid = models.BooleanField(blank=True, null=True)
+    misc = models.JSONField(blank=True, null=True)
+
+    class Meta:
+        managed = False
+        db_table = 'builds'

--- a/backend/poetry.lock
+++ b/backend/poetry.lock
@@ -262,26 +262,26 @@ type = ["mypy (>=1.8)"]
 
 [[package]]
 name = "psycopg"
-version = "3.1.19"
+version = "3.2.1"
 description = "PostgreSQL database adapter for Python"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "psycopg-3.1.19-py3-none-any.whl", hash = "sha256:dca5e5521c859f6606686432ae1c94e8766d29cc91f2ee595378c510cc5b0731"},
-    {file = "psycopg-3.1.19.tar.gz", hash = "sha256:92d7b78ad82426cdcf1a0440678209faa890c6e1721361c2f8901f0dccd62961"},
+    {file = "psycopg-3.2.1-py3-none-any.whl", hash = "sha256:ece385fb413a37db332f97c49208b36cf030ff02b199d7635ed2fbd378724175"},
+    {file = "psycopg-3.2.1.tar.gz", hash = "sha256:dc8da6dc8729dacacda3cc2f17d2c9397a70a66cf0d2b69c91065d60d5f00cb7"},
 ]
 
 [package.dependencies]
-typing-extensions = ">=4.1"
+typing-extensions = ">=4.4"
 tzdata = {version = "*", markers = "sys_platform == \"win32\""}
 
 [package.extras]
-binary = ["psycopg-binary (==3.1.19)"]
-c = ["psycopg-c (==3.1.19)"]
-dev = ["black (>=24.1.0)", "codespell (>=2.2)", "dnspython (>=2.1)", "flake8 (>=4.0)", "mypy (>=1.4.1)", "types-setuptools (>=57.4)", "wheel (>=0.37)"]
+binary = ["psycopg-binary (==3.2.1)"]
+c = ["psycopg-c (==3.2.1)"]
+dev = ["ast-comments (>=1.1.2)", "black (>=24.1.0)", "codespell (>=2.2)", "dnspython (>=2.1)", "flake8 (>=4.0)", "mypy (>=1.6)", "types-setuptools (>=57.4)", "wheel (>=0.37)"]
 docs = ["Sphinx (>=5.0)", "furo (==2022.6.21)", "sphinx-autobuild (>=2021.3.14)", "sphinx-autodoc-typehints (>=1.12)"]
 pool = ["psycopg-pool"]
-test = ["anyio (>=3.6.2,<4.0)", "mypy (>=1.4.1)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
+test = ["anyio (>=4.0)", "mypy (>=1.6)", "pproxy (>=2.7)", "pytest (>=6.2.5)", "pytest-cov (>=3.0)", "pytest-randomly (>=3.5)"]
 
 [[package]]
 name = "pycodestyle"


### PR DESCRIPTION
<!-- Open this PR as draft while it is not ready -->

## Description

- Add django models
- Add connection to database, it needs to be running on the background
- fix backend pre-commit
- todo: connect the database to docker-compose

## Related Issues
- Closes #22 

## How to test it
- Add a .env file by running a `cp .env.example .env`
- Fill the values with kcidb user/password
- Run kcidb_playground in the background
- Try to run `poetry run python3 manage.py inspectdb` to check if the app can get the db values
- Run `poetry run python3 manage.py shell` and inside the shell 
```python
from kernelCI_app.models import Issues
x = Issues.objects.all()
print(x)
```
and check if there is any issue object