### PR TITLE
fix: remove the Run Migrations step from the github workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,10 +122,6 @@ jobs:
         run: poetry install
         working-directory: ./backend
 
-      - name: Run migrations
-        run: poetry run python manage.py migrate --no-input
-        working-directory: ./backend
-
       - name: Lint
         run: poetry run flake8
         working-directory: ./backend


### PR DESCRIPTION
remove the Run Migrations step from the github workflow