### PR TITLE
fix: tree endpoint should calculate fields grouping by git_commit_hash

### DIFF
--- a/backend/kernelCI_app/serializers.py
+++ b/backend/kernelCI_app/serializers.py
@@ -15,13 +15,19 @@ class CheckoutsSerializer(serializers.ModelSerializer):
         ]
 
 
-class TreeSerializer(CheckoutsSerializer):
+class TreeSerializer(serializers.Serializer):
     build_status = serializers.SerializerMethodField(method_name="get_build_status")
     test_status = serializers.SerializerMethodField(method_name="get_test_status")
     tree_name = serializers.SerializerMethodField(method_name="get_tree_name")
+    git_commit_name = serializers.SerializerMethodField(method_name="get_git_commit_name")
+    git_repository_branch = serializers.SerializerMethodField(method_name="get_git_repository_branch")
+    git_commit_hash = serializers.SerializerMethodField(method_name="get_git_commit_hash")
 
-    class Meta(CheckoutsSerializer.Meta):
-        fields = CheckoutsSerializer.Meta.fields + ['build_status', 'test_status']
+    class Meta():
+        fields = [
+            'tree_name', 'git_commit_name', 'git_repository_branch',
+            'build_status', 'test_status', 'git_commit_hash'
+        ]
 
     def get_config(self, obj):
         return get_visible_record_config('checkouts', obj.id)
@@ -32,6 +38,15 @@ class TreeSerializer(CheckoutsSerializer):
 
     def get_tree_name(self, obj):
         return self.get_field_from_config(obj, 'tree_name')
+
+    def get_git_commit_name(self, obj):
+        return self.get_field_from_config(obj, 'git_commit_name')
+
+    def get_git_repository_branch(self, obj):
+        return self.get_field_from_config(obj, 'git_repository_branch')
+
+    def get_git_commit_hash(self, obj):
+        return obj.id
 
     def get_build_status(self, obj):
         return {

--- a/backend/kernelCI_app/utils.py
+++ b/backend/kernelCI_app/utils.py
@@ -2,7 +2,7 @@ def get_visible_records(table_name):
     return visible_records.get(table_name, {})
 
 
-def get_visible_record_ids(table_name):
+def get_visible_record_identifiers(table_name):
     return list(get_visible_records(table_name).keys())
 
 
@@ -12,23 +12,40 @@ def get_visible_record_config(table_name, id):
 
 visible_records = {
     "checkouts": {
-        "broonie:7592653346c84691a16ccd1c115df05c": {
+        "22a40d14b572deb80c0648557f4bd502d7e83826": {
             "tree_name": "mainline",
+            "git_repository_branch": "master",
+            "git_commit_name": "v6.10-rc6"
         },
-        "broonie:170e93ec1178448293bb3b1163b1a4ee": {
+        "61945f2f69d080a9cf2c879cb959d4648df9b94c": {
             "tree_name": "stable",
+            "git_repository_branch": "linux-6.6.y",
+            "git_commit_name": "v6.6.36"
         },
-        "broonie:88964264010d43159ffa28bb524be058": {
+        "99e6a620de00b96f059c9e7f14b5795ca0c6b125": {
             "tree_name": "stable",
+            "git_repository_branch": "linux-6.1.y",
+            "git_commit_name": "v6.1.96"
         },
-        "broonie:12f55b2668fb4eca9254bfadad4ee871": {
+        "4878aadf2d1519f3731ae300ce1fef78fc63ee30": {
             "tree_name": "stable",
+            "git_repository_branch": "linux-5.15.y",
+            "git_commit_name": "v5.15.161"
         },
-        "broonie:c4ea3368208f4909b5af51c6a148047d": {
+        "3a3877de44342d0a09216dfbe674a404e8f5e96f": {
             "tree_name": "stable",
+            "git_repository_branch": "linux-5.10.y",
+            "git_commit_name": "v5.10.220"
         },
-        "broonie:1b17e613a3e94254af6fef1167572d35": {
+        "189ee9735a4b2e8095b1a6c088ebc8e133872471": {
             "tree_name": "stable",
+            "git_repository_branch": "linux-5.4.y",
+            "git_commit_name": "v5.4.278"
+        },
+        "b37477f5316fe37f74645a5d9d92a3a9c93d8cfa": {
+            "tree_name": "stable",
+            "git_repository_branch": "linux-4.19.y",
+            "git_commit_name": "v4.19.316"
         },
     }
 }

--- a/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
+++ b/dashboard/src/components/TreeListingPage/TreeListingPage.tsx
@@ -75,7 +75,7 @@ const TreeListingPage = (): JSX.Element => {
         return [];
       } else {
           return((data as Tree[]).map(tree => {
-            const fullHash = tree.git_commit_hash ?? tree.patchset_hash ?? '';
+            const fullHash = tree.git_commit_hash ?? '';
             const commitHash = fullHash.substring(0, NUMBER_CHAR_HASH) + (fullHash.length > NUMBER_CHAR_HASH ? '...' : '');
             const tagCommit = tree.git_commit_name ? `${tree.git_commit_name} - ${commitHash}` : commitHash;
 

--- a/dashboard/src/types/tree/Tree.tsx
+++ b/dashboard/src/types/tree/Tree.tsx
@@ -7,24 +7,10 @@ export type TreeTableBody = {
 }
 
 export type Tree = {
-    _timestamp: string;
-    id:	string;
-    origin:	string | null;
     tree_name: string | null;
-    git_repository_url:	string | null;
     git_commit_hash: string | null;
     git_commit_name: string | null;
     git_repository_branch: string | null;
-    patchset_files: string | null;
-    patchset_hash: string | null;
-    message_id: string | null;
-    comment: string | null;
-    start_time: string | null;
-    contacts: string | null;
-    log_url: string | null;
-    log_excerpt: string | null;
-    valid: boolean;
-    misc: JSON;
     build_status: {
       valid: number;
       invalid: number;


### PR DESCRIPTION
- calculate build_status and test_status grouping by checkouts.git_commit_hash instead of checkouts.id
- `git_repository_branch` and `git_commit_name` should come from config
- remove fields from the front-end that are no longer related to the tree