### PR TITLE
fix: accordion link was without href

### DIFF
--- a/dashboard/src/components/LinkGroup/LinkGroup.tsx
+++ b/dashboard/src/components/LinkGroup/LinkGroup.tsx
@@ -23,6 +23,7 @@ const LinksGroup = ({ links }: ILinkGroup): JSX.Element => {
             icon={link.icon}
             linkText={link.linkText}
             key={link.link}
+            link={link.link}
           />
         ),
     );

--- a/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
+++ b/dashboard/src/components/LinkWithIcon/LinkWithIcon.tsx
@@ -16,7 +16,12 @@ const LinkWithIcon = ({
   return (
     <div className="flex flex-col gap-2">
       <span className="font-bold">{title}</span>
-      <a className="flex flex-row gap-1 items-center" href={link}>
+      <a
+        className="flex flex-row gap-1 items-center"
+        href={link}
+        target="_blank"
+        rel="noreferrer"
+      >
         {linkText}
         {icon}
       </a>


### PR DESCRIPTION
- also use target as `_blank`
- accordion link was without href
